### PR TITLE
fix: menu button color

### DIFF
--- a/src/components/HeadCellMenu/styles.ts
+++ b/src/components/HeadCellMenu/styles.ts
@@ -24,7 +24,6 @@ export const HeadCellMenuWrapper = styled(Box)(({ rightAligned }: { rightAligned
 
 export const StyledMenuButton = styled(Menu)(() => ({
   minWidth: 'unset',
-  color: '#404040',
   cursor: 'pointer',
 }));
 


### PR DESCRIPTION
Fixes an issue where the "hamburger icon" would not inherit the color from it's parent. Thus the colors would not match.

Before:
![Skärmavbild 2023-09-01 kl  09 01 46](https://github.com/qlik-oss/nebula-table-utils/assets/16608020/217a5412-d9b2-4982-b6eb-1a05c6c74e38)

After:
![Skärmavbild 2023-09-01 kl  08 53 43](https://github.com/qlik-oss/nebula-table-utils/assets/16608020/1d15e05a-76bd-4ff7-81b6-e0384ac9c06b)
