### PR TITLE
feat: to rgb

### DIFF
--- a/src/utils/color-utils/index.ts
+++ b/src/utils/color-utils/index.ts
@@ -2,3 +2,5 @@ export { default as COLORING } from './coloring';
 export { default as getHoverColor } from './get-hover-color';
 export { default as isDarkColor } from './is-dark-color';
 export { default as isTransparent } from './is-transparent-color';
+export { default as toRGB } from './to-rgb';
+export { default as removeOpacity } from './remove-opacity';

--- a/src/utils/color-utils/remove-opacity/index.ts
+++ b/src/utils/color-utils/remove-opacity/index.ts
@@ -1,0 +1,14 @@
+import { toRGB } from '../to-rgb';
+
+const removeOpacity = (color: string | undefined) => {
+  if (color === undefined) {
+    return undefined;
+  }
+
+  const rgb = toRGB(color);
+  rgb.opacity = 1;
+
+  return rgb.toString();
+};
+
+export default removeOpacity;

--- a/src/utils/color-utils/remove-opacity/remove-opacity.test.ts
+++ b/src/utils/color-utils/remove-opacity/remove-opacity.test.ts
@@ -1,0 +1,11 @@
+import removeOpacity from '.';
+
+describe('removeOpacity', () => {
+  test('should remove opacity from ARGB', () => {
+    expect(removeOpacity('ARGB(153, 20, 40, 60)')).toEqual('rgb(20, 40, 60)');
+  });
+
+  test('should remove opacity from RGBA', () => {
+    expect(removeOpacity('rgba(20, 40, 60, 0.5)')).toEqual('rgb(20, 40, 60)');
+  });
+});

--- a/src/utils/color-utils/to-rgb/index.ts
+++ b/src/utils/color-utils/to-rgb/index.ts
@@ -14,6 +14,14 @@ export const toRGB = (color: string) => {
   return rgb(color);
 };
 
-const toRGBString = (color: string) => toRGB(color).toString();
+const toRGBString = (color: string) => {
+  const RGBColor = toRGB(color);
+
+  if (Number.isNaN(RGBColor.r)) {
+    return null;
+  }
+
+  return RGBColor.toString();
+};
 
 export default toRGBString;

--- a/src/utils/color-utils/to-rgb/index.ts
+++ b/src/utils/color-utils/to-rgb/index.ts
@@ -1,0 +1,19 @@
+import { rgb } from 'd3-color';
+
+const ARGB_REGEX = /^argb\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*\)$/i;
+
+export const toRGB = (color: string) => {
+  const matches = ARGB_REGEX.exec(color);
+
+  if (matches) {
+    const [, a, r, g, b] = matches;
+    const normalizedAlpha = +a / 255;
+    return rgb(+r, +g, +b, normalizedAlpha);
+  }
+
+  return rgb(color);
+};
+
+const toRGBString = (color: string) => toRGB(color).toString();
+
+export default toRGBString;

--- a/src/utils/color-utils/to-rgb/to-rgb.test.ts
+++ b/src/utils/color-utils/to-rgb/to-rgb.test.ts
@@ -5,6 +5,10 @@ describe('toRGB', () => {
     expect(toRGBString('ARGB(153, 20, 40, 60)')).toEqual('rgba(20, 40, 60, 0.6)');
   });
 
+  test('should convert ARGB without space to rgba', () => {
+    expect(toRGBString('ARGB(153,20,40,60)')).toEqual('rgba(20, 40, 60, 0.6)');
+  });
+
   test('should convert argb to rgba', () => {
     expect(toRGBString('argb(153, 20, 40, 60)')).toEqual('rgba(20, 40, 60, 0.6)');
   });
@@ -15,6 +19,10 @@ describe('toRGB', () => {
 
   test('should convert RGB to rgb', () => {
     expect(toRGBString('RGB(20, 40, 60)')).toEqual('rgb(20, 40, 60)');
+  });
+
+  test('should convert rgb without space to rgb', () => {
+    expect(toRGBString('RGB(20,40,60)')).toEqual('rgb(20, 40, 60)');
   });
 
   test('should convert hex to rgb', () => {

--- a/src/utils/color-utils/to-rgb/to-rgb.test.ts
+++ b/src/utils/color-utils/to-rgb/to-rgb.test.ts
@@ -1,0 +1,23 @@
+import toRGBString from '.';
+
+describe('toRGB', () => {
+  test('should convert ARGB to rgba', () => {
+    expect(toRGBString('ARGB(153, 20, 40, 60)')).toEqual('rgba(20, 40, 60, 0.6)');
+  });
+
+  test('should convert argb to rgba', () => {
+    expect(toRGBString('argb(153, 20, 40, 60)')).toEqual('rgba(20, 40, 60, 0.6)');
+  });
+
+  test('should convert hsl to rgb', () => {
+    expect(toRGBString('hsl(90, 50%, 50%)')).toEqual('rgb(128, 191, 64)');
+  });
+
+  test('should convert RGB to rgb', () => {
+    expect(toRGBString('RGB(20, 40, 60)')).toEqual('rgb(20, 40, 60)');
+  });
+
+  test('should convert hex to rgb', () => {
+    expect(toRGBString('#404040')).toEqual('rgb(64, 64, 64)');
+  });
+});

--- a/src/utils/color-utils/to-rgb/to-rgb.test.ts
+++ b/src/utils/color-utils/to-rgb/to-rgb.test.ts
@@ -17,6 +17,10 @@ describe('toRGB', () => {
     expect(toRGBString('hsl(90, 50%, 50%)')).toEqual('rgb(128, 191, 64)');
   });
 
+  test('should convert hsla to rgba', () => {
+    expect(toRGBString('hsla(90, 50%, 50%, 0.5)')).toEqual('rgba(128, 191, 64, 0.5)');
+  });
+
   test('should convert RGB to rgb', () => {
     expect(toRGBString('RGB(20, 40, 60)')).toEqual('rgb(20, 40, 60)');
   });
@@ -25,7 +29,23 @@ describe('toRGB', () => {
     expect(toRGBString('RGB(20,40,60)')).toEqual('rgb(20, 40, 60)');
   });
 
-  test('should convert hex to rgb', () => {
+  test('should convert 3 digit hex to rgba', () => {
+    expect(toRGBString('#f09')).toEqual('rgb(255, 0, 153)');
+  });
+
+  test('should convert 4 digit hex to rgba', () => {
+    expect(toRGBString('#4049')).toEqual('rgba(68, 0, 68, 0.6)');
+  });
+
+  test('should convert 6 digit hex to rgb', () => {
     expect(toRGBString('#404040')).toEqual('rgb(64, 64, 64)');
+  });
+
+  test('should convert 8 digit hex to rgba', () => {
+    expect(toRGBString('#40404099')).toEqual('rgba(64, 64, 64, 0.6)');
+  });
+
+  test('should handle invalid color strings', () => {
+    expect(toRGBString('invalid color')).toBe(null);
   });
 });

--- a/src/utils/color-utils/to-rgb/to-rgb.test.ts
+++ b/src/utils/color-utils/to-rgb/to-rgb.test.ts
@@ -29,7 +29,7 @@ describe('toRGB', () => {
     expect(toRGBString('RGB(20,40,60)')).toEqual('rgb(20, 40, 60)');
   });
 
-  test('should convert 3 digit hex to rgba', () => {
+  test('should convert 3 digit hex to rgb', () => {
     expect(toRGBString('#f09')).toEqual('rgb(255, 0, 153)');
   });
 


### PR DESCRIPTION
Both sn-pivot-table and sn-table needs to convert the color space string coming from Engine. `toRGB` provides a shared function for doing so.