### PR TITLE
fix: calling `setIsAdjustingWidth` to block other cell events + new min width for sn-table  

### DIFF
--- a/src/components/ColumnAdjuster/ColumnAdjuster.tsx
+++ b/src/components/ColumnAdjuster/ColumnAdjuster.tsx
@@ -27,11 +27,14 @@ const ColumnAdjuster = ({
   handleBlur,
 }: ColumnAdjusterProps) => {
   const tempWidth = useMemo(() => ({ initWidth: columnWidth, columnWidth, initX: 0 }), [columnWidth]);
+  // TODO: only use PixelsMin when we switch to the new header, needs to listen to the flag
+  const minWidth = isPivot ? ColumnWidthValues.PixelsMin : ColumnWidthValues.PixelsMinTable;
+  const leftAdjustment = isLastColumn ? 0 : 1;
+  const style = { left: isPivot ? tempWidth.columnWidth - leftAdjustment : '100%' };
 
   // Note that deltaWidth is the change since you started the resize
   const updateWidth = (deltaWidth: number) => {
-    // TODO: table and pivot table min widths are different at this point
-    const adjustedWidth = Math.max(tempWidth.initWidth + deltaWidth, ColumnWidthValues.PixelsMin);
+    const adjustedWidth = Math.max(tempWidth.initWidth + deltaWidth, minWidth);
     tempWidth.columnWidth = adjustedWidth;
     updateWidthCallback(adjustedWidth);
   };
@@ -117,9 +120,6 @@ const ColumnAdjuster = ({
           }
         }
       : undefined;
-
-  const leftAdjustment = isLastColumn ? 0 : 1;
-  const style = { left: isPivot ? tempWidth.columnWidth - leftAdjustment : '100%' };
 
   return (
     <AdjusterHitArea

--- a/src/components/ColumnAdjuster/ColumnAdjuster.tsx
+++ b/src/components/ColumnAdjuster/ColumnAdjuster.tsx
@@ -22,13 +22,14 @@ const ColumnAdjuster = ({
   keyValue,
   isLastColumn,
   isPivot,
+  isNewHeadCellMenuEnabled,
   updateWidthCallback,
   confirmWidthCallback,
   handleBlur,
 }: ColumnAdjusterProps) => {
   const tempWidth = useMemo(() => ({ initWidth: columnWidth, columnWidth, initX: 0 }), [columnWidth]);
   // TODO: only use PixelsMin when we switch to the new header, needs to listen to the flag
-  const minWidth = isPivot ? ColumnWidthValues.PixelsMin : ColumnWidthValues.PixelsMinTable;
+  const minWidth = isPivot || isNewHeadCellMenuEnabled ? ColumnWidthValues.PixelsMin : ColumnWidthValues.PixelsMinTable;
   const leftAdjustment = isLastColumn ? 0 : 1;
   const style = { left: isPivot ? tempWidth.columnWidth - leftAdjustment : '100%' };
 

--- a/src/components/ColumnAdjuster/ColumnAdjuster.tsx
+++ b/src/components/ColumnAdjuster/ColumnAdjuster.tsx
@@ -26,6 +26,7 @@ const ColumnAdjuster = ({
   updateWidthCallback,
   confirmWidthCallback,
   handleBlur,
+  setIsAdjustingWidth,
 }: ColumnAdjusterProps) => {
   const tempWidth = useMemo(() => ({ initWidth: columnWidth, columnWidth, initX: 0 }), [columnWidth]);
   // TODO: only use PixelsMin when we switch to the new header, needs to listen to the flag
@@ -44,6 +45,8 @@ const ColumnAdjuster = ({
     if (tempWidth.columnWidth !== tempWidth.initWidth) {
       const newWidthData = { type: ColumnWidthType.Pixels, pixels: tempWidth.columnWidth };
       confirmWidthCallback(newWidthData);
+    } else {
+      setIsAdjustingWidth?.(false);
     }
   };
 
@@ -66,6 +69,7 @@ const ColumnAdjuster = ({
     document.addEventListener('mousemove', mouseMoveHandler);
     document.addEventListener('mouseup', mouseUpHandler);
 
+    setIsAdjustingWidth?.(true);
     tempWidth.initX = evt.clientX;
   };
 
@@ -93,6 +97,7 @@ const ColumnAdjuster = ({
     document.addEventListener('touchmove', touchMoveHandler);
     document.addEventListener('touchend', touchEndHandler);
 
+    setIsAdjustingWidth?.(true);
     tempWidth.initX = evt.touches[0].clientX;
   };
 

--- a/src/components/ColumnAdjuster/__tests__/ColumnAdjuster.test.tsx
+++ b/src/components/ColumnAdjuster/__tests__/ColumnAdjuster.test.tsx
@@ -8,6 +8,7 @@ describe('<ColumnAdjuster />', () => {
   const defaultWidth = 150;
   let updateWidthCallback: (pageColIdx: number) => void;
   let confirmWidthCallback: (newWidthData: ColumnWidth) => void;
+  let setIsAdjustingWidth: (isAdjusting: boolean) => void;
 
   const renderAdjuster = () => {
     render(
@@ -18,6 +19,7 @@ describe('<ColumnAdjuster />', () => {
         updateWidthCallback={updateWidthCallback}
         confirmWidthCallback={confirmWidthCallback}
         handleBlur={() => {}}
+        setIsAdjustingWidth={setIsAdjustingWidth}
       />
     );
     return screen.queryByTestId(COLUMN_ADJUSTER_CLASS) as HTMLElement;
@@ -26,6 +28,7 @@ describe('<ColumnAdjuster />', () => {
   beforeEach(() => {
     updateWidthCallback = jest.fn();
     confirmWidthCallback = jest.fn();
+    setIsAdjustingWidth = jest.fn();
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -51,6 +54,7 @@ describe('<ColumnAdjuster />', () => {
     fireEvent.keyDown(columnAdjuster, { key: KeyCodes.SPACE });
     await waitFor(() => {
       expect(confirmWidthCallback).toHaveBeenCalledTimes(0);
+      expect(setIsAdjustingWidth).toHaveBeenNthCalledWith(1, false);
     });
 
     fireEvent.keyDown(columnAdjuster, { key: KeyCodes.ESC });
@@ -68,6 +72,7 @@ describe('<ColumnAdjuster />', () => {
     fireEvent.mouseMove(columnAdjuster, options);
     await waitFor(() => {
       expect(updateWidthCallback).toHaveBeenCalledWith(options.clientX);
+      expect(setIsAdjustingWidth).toHaveBeenNthCalledWith(1, true);
     });
 
     fireEvent.mouseUp(columnAdjuster, options);
@@ -76,6 +81,7 @@ describe('<ColumnAdjuster />', () => {
         type: ColumnWidthType.Pixels,
         pixels: options.clientX,
       });
+      expect(setIsAdjustingWidth).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -86,6 +92,8 @@ describe('<ColumnAdjuster />', () => {
     fireEvent.mouseUp(columnAdjuster);
     await waitFor(() => {
       expect(confirmWidthCallback).not.toHaveBeenCalled();
+      expect(setIsAdjustingWidth).toHaveBeenNthCalledWith(1, true);
+      expect(setIsAdjustingWidth).toHaveBeenNthCalledWith(2, false);
     });
   });
 
@@ -113,6 +121,7 @@ describe('<ColumnAdjuster />', () => {
     fireEvent.touchMove(columnAdjuster, options);
     await waitFor(() => {
       expect(updateWidthCallback).toHaveBeenCalledWith(options.touches[0].clientX);
+      expect(setIsAdjustingWidth).toHaveBeenNthCalledWith(1, true);
     });
 
     fireEvent.touchEnd(columnAdjuster, options);
@@ -121,6 +130,7 @@ describe('<ColumnAdjuster />', () => {
         type: ColumnWidthType.Pixels,
         pixels: options.touches[0].clientX,
       });
+      expect(setIsAdjustingWidth).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/components/ColumnAdjuster/__tests__/ColumnAdjuster.test.tsx
+++ b/src/components/ColumnAdjuster/__tests__/ColumnAdjuster.test.tsx
@@ -5,7 +5,7 @@ import ColumnAdjuster from '../ColumnAdjuster';
 import { type ColumnWidth } from '../types';
 
 describe('<ColumnAdjuster />', () => {
-  const defaultWidth = 50;
+  const defaultWidth = 150;
   let updateWidthCallback: (pageColIdx: number) => void;
   let confirmWidthCallback: (newWidthData: ColumnWidth) => void;
 
@@ -64,7 +64,7 @@ describe('<ColumnAdjuster />', () => {
     const options = { clientX: defaultWidth };
 
     fireEvent.mouseDown(columnAdjuster, options);
-    options.clientX = 100;
+    options.clientX = 200;
     fireEvent.mouseMove(columnAdjuster, options);
     await waitFor(() => {
       expect(updateWidthCallback).toHaveBeenCalledWith(options.clientX);
@@ -109,7 +109,7 @@ describe('<ColumnAdjuster />', () => {
     };
 
     fireEvent.touchStart(columnAdjuster, options);
-    options.touches[0].clientX = 100;
+    options.touches[0].clientX = 200;
     fireEvent.touchMove(columnAdjuster, options);
     await waitFor(() => {
       expect(updateWidthCallback).toHaveBeenCalledWith(options.touches[0].clientX);
@@ -137,7 +137,7 @@ describe('<ColumnAdjuster />', () => {
     };
 
     fireEvent.touchStart(columnAdjuster, options);
-    options.touches[0].clientX = 100;
+    options.touches[0].clientX = 200;
     fireEvent.touchMove(columnAdjuster, options);
     await waitFor(() => {
       expect(updateWidthCallback).not.toHaveBeenCalled();

--- a/src/components/ColumnAdjuster/types.ts
+++ b/src/components/ColumnAdjuster/types.ts
@@ -11,6 +11,7 @@ export interface ColumnAdjusterProps {
   keyValue: string;
   isLastColumn: boolean;
   isPivot?: boolean;
+  isNewHeadCellMenuEnabled?: boolean;
   updateWidthCallback: (pageColIdx: number) => void;
   confirmWidthCallback: (newWidthData: ColumnWidth) => void;
   handleBlur?: (event: React.KeyboardEvent | React.FocusEvent) => void;

--- a/src/components/ColumnAdjuster/types.ts
+++ b/src/components/ColumnAdjuster/types.ts
@@ -15,4 +15,5 @@ export interface ColumnAdjusterProps {
   updateWidthCallback: (pageColIdx: number) => void;
   confirmWidthCallback: (newWidthData: ColumnWidth) => void;
   handleBlur?: (event: React.KeyboardEvent | React.FocusEvent) => void;
+  setIsAdjustingWidth?: (isAdjusting: boolean) => void;
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -28,6 +28,7 @@ export const COLUMN_ADJUSTER_BORDER_CLASS = `${COLUMN_ADJUSTER_CLASS}-border`;
 
 export enum ColumnWidthValues {
   PixelsMin = 30,
+  PixelsMinTable = 120, // TODO: remove this value when we remove the new header flag
   PixelsMax = 7680,
   PixelsDefault = 200,
   PercentageMin = 1,


### PR DESCRIPTION
- In order to block click events on the dimension value cells and header cells, we need to know when the column adjuster is being dragged or not. Therefor we add a state in sn-pivot-table, then passing the setter in here and set it to true when you start dragging. If you haven't changed the width, the state is set to false, since there is no way for pivot table to know that you are done dragging, without calling the `confirmCallback`. Note that there is still a small bug you can get. If you have the min width aldready, then start to drag over the cell and release, you will trigger the cell click handler. This is an extreme corner-case, that will be fixed if we implement drag to select. See both the fix and lastly the remaining bug in the gif
![Kapture 2023-11-14 at 15 53 29](https://github.com/qlik-oss/nebula-table-utils/assets/9249820/6cc9fd7e-358c-4a62-ab30-9d77dcca4473)


- Adding a new min value which is the current one for sn-table. We need to use that value when we have the old header implementation, to fit both buttons. Once we turn on the flag for the new header, we can switch only having one min value (30px)