### PR TITLE
fix: use hoverColor to set the hover color

### DIFF
--- a/src/components/ColumnAdjuster/ColumnAdjuster.tsx
+++ b/src/components/ColumnAdjuster/ColumnAdjuster.tsx
@@ -23,7 +23,7 @@ const ColumnAdjuster = ({
   isLastColumn,
   isPivot,
   isNewHeadCellMenuEnabled,
-  borderColor,
+  hoverColor,
   updateWidthCallback,
   confirmWidthCallback,
   handleBlur,
@@ -132,7 +132,7 @@ const ColumnAdjuster = ({
     <AdjusterHitArea
       className={COLUMN_ADJUSTER_CLASS}
       isLastColumn={isLastColumn}
-      borderColor={borderColor}
+      hoverColor={hoverColor}
       style={style}
       key={keyValue}
       onMouseDown={mouseDownHandler}

--- a/src/components/ColumnAdjuster/ColumnAdjuster.tsx
+++ b/src/components/ColumnAdjuster/ColumnAdjuster.tsx
@@ -23,6 +23,7 @@ const ColumnAdjuster = ({
   isLastColumn,
   isPivot,
   isNewHeadCellMenuEnabled,
+  borderColor,
   updateWidthCallback,
   confirmWidthCallback,
   handleBlur,
@@ -131,6 +132,7 @@ const ColumnAdjuster = ({
     <AdjusterHitArea
       className={COLUMN_ADJUSTER_CLASS}
       isLastColumn={isLastColumn}
+      borderColor={borderColor}
       style={style}
       key={keyValue}
       onMouseDown={mouseDownHandler}

--- a/src/components/ColumnAdjuster/styles.ts
+++ b/src/components/ColumnAdjuster/styles.ts
@@ -8,8 +8,8 @@ const CELL_PADDING = 4;
 const GRID_BORDER = 1;
 
 export const AdjusterHitArea = styled(Box, {
-  shouldForwardProp: (prop: ShouldForwardProp) => prop !== 'isLastColumn' && prop !== 'borderColor',
-})(({ isLastColumn, borderColor }) => ({
+  shouldForwardProp: (prop: ShouldForwardProp) => prop !== 'isLastColumn' && prop !== 'hoverColor',
+})(({ isLastColumn, hoverColor }) => ({
   pointerEvents: 'auto',
   touchAction: 'none',
   display: 'flex',
@@ -23,7 +23,7 @@ export const AdjusterHitArea = styled(Box, {
   marginLeft: '-4px',
   '&:hover:not(:focus, :active)': {
     [`& .${COLUMN_ADJUSTER_BORDER_CLASS}`]: {
-      background: borderColor || '#D9D9D9',
+      background: hoverColor || '#D9D9D9',
       '@media (hover: none)': {
         background: 'none',
       },

--- a/src/components/ColumnAdjuster/styles.ts
+++ b/src/components/ColumnAdjuster/styles.ts
@@ -8,8 +8,8 @@ const CELL_PADDING = 4;
 const GRID_BORDER = 1;
 
 export const AdjusterHitArea = styled(Box, {
-  shouldForwardProp: (prop: ShouldForwardProp) => prop !== 'isLastColumn',
-})(({ isLastColumn }) => ({
+  shouldForwardProp: (prop: ShouldForwardProp) => prop !== 'isLastColumn' && prop !== 'borderColor',
+})(({ isLastColumn, borderColor }) => ({
   pointerEvents: 'auto',
   touchAction: 'none',
   display: 'flex',
@@ -23,7 +23,7 @@ export const AdjusterHitArea = styled(Box, {
   marginLeft: '-4px',
   '&:hover:not(:focus, :active)': {
     [`& .${COLUMN_ADJUSTER_BORDER_CLASS}`]: {
-      background: '#D9D9D9',
+      background: borderColor || '#D9D9D9',
       '@media (hover: none)': {
         background: 'none',
       },
@@ -33,6 +33,8 @@ export const AdjusterHitArea = styled(Box, {
     outline: 'none',
     [`& .${COLUMN_ADJUSTER_BORDER_CLASS}`]: {
       background: '#177fe6',
+      borderLeft: '1px solid #fff',
+      borderRight: !isLastColumn ? '1px solid #fff' : undefined,
     },
   },
 }));

--- a/src/components/ColumnAdjuster/types.ts
+++ b/src/components/ColumnAdjuster/types.ts
@@ -12,7 +12,7 @@ export interface ColumnAdjusterProps {
   isLastColumn: boolean;
   isPivot?: boolean;
   isNewHeadCellMenuEnabled?: boolean;
-  borderColor?: string;
+  hoverColor?: string;
   updateWidthCallback: (pageColIdx: number) => void;
   confirmWidthCallback: (newWidthData: ColumnWidth) => void;
   handleBlur?: (event: React.KeyboardEvent | React.FocusEvent) => void;

--- a/src/components/ColumnAdjuster/types.ts
+++ b/src/components/ColumnAdjuster/types.ts
@@ -12,6 +12,7 @@ export interface ColumnAdjusterProps {
   isLastColumn: boolean;
   isPivot?: boolean;
   isNewHeadCellMenuEnabled?: boolean;
+  borderColor?: string;
   updateWidthCallback: (pageColIdx: number) => void;
   confirmWidthCallback: (newWidthData: ColumnWidth) => void;
   handleBlur?: (event: React.KeyboardEvent | React.FocusEvent) => void;


### PR DESCRIPTION
Takes a new prop called hoverColor that is used as hover color. It is optional, defaults to the default border color of the tables