### PR TITLE
fix: remove tabIndex from hamburger button

### DIFF
--- a/src/components/HeadCellMenu/HeadCellMenu.tsx
+++ b/src/components/HeadCellMenu/HeadCellMenu.tsx
@@ -11,7 +11,6 @@ import { HEAD_CELL_MENU_BUTTON_CLASS } from '../../constants';
 const HeadCellMenu = ({
   open,
   setOpen,
-  tabIndex,
   anchorRef,
   headerData,
   translator,
@@ -72,11 +71,7 @@ const HeadCellMenu = ({
   if (!interactions.active) return null;
 
   return (
-    <HeadCellMenuWrapper
-      tabIndex={tabIndex}
-      rightAligned={headTextAlign === 'right'}
-      shouldShowMenuIcon={shouldShowMenuIcon}
-    >
+    <HeadCellMenuWrapper rightAligned={headTextAlign === 'right'} shouldShowMenuIcon={shouldShowMenuIcon}>
       {shouldShowMenuIcon && (
         <StyledMenuButton
           size="small"

--- a/src/components/HeadCellMenu/__tests__/HeadCellMenu.test.tsx
+++ b/src/components/HeadCellMenu/__tests__/HeadCellMenu.test.tsx
@@ -60,7 +60,6 @@ describe('<HeadCellMenu />', () => {
         translator={translator}
         anchorRef={anchorRef}
         headerData={headerData}
-        tabIndex={0}
         interactions={interactions}
         menuAvailabilityFlags={menuAvailabilityFlags}
         handleHeadCellMenuKeyDown={handleHeadCellMenuKeyDown}

--- a/src/components/HeadCellMenu/types.ts
+++ b/src/components/HeadCellMenu/types.ts
@@ -30,7 +30,6 @@ export type AdjustHeaderSizeRelatedArgs = {
 export interface HeadCellMenuProps {
   headerData: HeaderData;
   translator: stardust.Translator;
-  tabIndex: number;
   anchorRef: React.RefObject<HTMLDivElement>;
   handleHeadCellMenuKeyDown?: (evt: React.KeyboardEvent<HTMLLIElement>) => void;
   menuAvailabilityFlags: Partial<Record<MenuAvailabilityFlags, boolean>>;


### PR DESCRIPTION
the tab index prop is useless now, since there might not be any tab stop in specifically hamburger menu button because the entire cell is clickable by design

Related PRs in:
SNT: https://github.com/qlik-oss/sn-table/pull/1108
PVT: https://github.com/qlik-oss/sn-pivot-table/pull/494