### PR TITLE
fix: column adjuster pivot position

### DIFF
--- a/src/components/ColumnAdjuster/ColumnAdjuster.tsx
+++ b/src/components/ColumnAdjuster/ColumnAdjuster.tsx
@@ -28,12 +28,13 @@ const ColumnAdjuster = ({
   confirmWidthCallback,
   handleBlur,
   setIsAdjustingWidth,
+  isLeftColumn,
 }: ColumnAdjusterProps) => {
   const tempWidth = useMemo(() => ({ initWidth: columnWidth, columnWidth, initX: 0 }), [columnWidth]);
   // TODO: only use PixelsMin when we switch to the new header, needs to listen to the flag
   const minWidth = isPivot || isNewHeadCellMenuEnabled ? ColumnWidthValues.PixelsMin : ColumnWidthValues.PixelsMinTable;
   const leftAdjustment = isLastColumn ? 0 : 1;
-  const style = { left: isPivot ? tempWidth.columnWidth - leftAdjustment : '100%' };
+  const style = { left: isPivot && !isLeftColumn ? tempWidth.columnWidth - leftAdjustment : '100%' };
 
   // Note that deltaWidth is the change since you started the resize
   const updateWidth = (deltaWidth: number) => {

--- a/src/components/ColumnAdjuster/types.ts
+++ b/src/components/ColumnAdjuster/types.ts
@@ -17,4 +17,5 @@ export interface ColumnAdjusterProps {
   confirmWidthCallback: (newWidthData: ColumnWidth) => void;
   handleBlur?: (event: React.KeyboardEvent | React.FocusEvent) => void;
   setIsAdjustingWidth?: (isAdjusting: boolean) => void;
+  isLeftColumn?: boolean;
 }


### PR DESCRIPTION
Fixes an issue in the pivot table when a horizontal scrollbar appared because the ColumnAdjuster would overflow the parent container on the last column.

Before:
![Skärmavbild 2023-12-21 kl  14 38 23](https://github.com/qlik-oss/nebula-table-utils/assets/16608020/767e7234-7fbc-442b-aaac-798a690c06ec)


After:
![Skärmavbild 2023-12-21 kl  14 37 57](https://github.com/qlik-oss/nebula-table-utils/assets/16608020/c3381344-3262-4a2e-85a8-502da6cb976f)
